### PR TITLE
Update Gap to support Gleam v0.33.0

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -1,6 +1,6 @@
 name = "gap"
-gleam = ">= 0.32.2"
-version = "1.0.1"
+gleam = ">= 0.33.0"
+version = "1.0.2"
 description = "A Gleam library for comparing strings/lists and producing a textual (styled) representation of the differences."
 
 # Fill out these fields if you intend to generate HTML documentation or publish
@@ -11,8 +11,8 @@ repository = { type = "github", user = "JohnBjrk", repo = "gap" }
 # links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.32"
-gleam_community_ansi = "~> 1.2"
+gleam_stdlib = "~> 0.34"
+gleam_community_ansi = "~> 1.4"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,13 +2,13 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_community_ansi", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_community_colour"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "8B5A9677BC5A2738712BBAF2BA289B1D8195FDF962BBC769569976AD5E9794E1" },
-  { name = "gleam_community_colour", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "036C206886AFB9F153C552700A7A0B4D2864E3BC96A20C77E5F34A013C051BE3" },
-  { name = "gleam_stdlib", version = "0.32.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "07D64C26D014CF570F8ACADCE602761EA2E74C842D26F2FD49B0D61973D9966F" },
-  { name = "gleeunit", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D3682ED8C5F9CAE1C928F2506DE91625588CC752495988CBE0F5653A42A6F334" },
+  { name = "gleam_community_ansi", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "FE79E08BF97009729259B6357EC058315B6FBB916FAD1C2FF9355115FEB0D3A4" },
+  { name = "gleam_community_colour", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "A49A5E3AE8B637A5ACBA80ECB9B1AFE89FD3D5351FF6410A42B84F666D40D7D5" },
+  { name = "gleam_stdlib", version = "0.34.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1FB8454D2991E9B4C0C804544D8A9AD0F6184725E20D63C3155F0AEB4230B016" },
+  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
 ]
 
 [requirements]
-gleam_community_ansi = { version = "~> 1.2" }
-gleam_stdlib = { version = "~> 0.32" }
+gleam_community_ansi = { version = "~> 1.4" }
+gleam_stdlib = { version = "~> 0.34" }
 gleeunit = { version = "~> 1.0" }

--- a/src/gap/myers.gleam
+++ b/src/gap/myers.gleam
@@ -93,6 +93,7 @@ fn proceed_path(
         False -> #(move_down(path2), [path2, ..rest])
       }
     }
+    _, _, _ -> panic as "Unexpected case"
   }
 }
 

--- a/src/gap/styling.gleam
+++ b/src/gap/styling.gleam
@@ -160,7 +160,8 @@ pub fn no_highlight(string: String) -> String {
 fn string_serializer(part: Part(String)) -> String {
   case part {
     Part(acc, sequence, highlight) ->
-      acc <> {
+      acc
+      <> {
         sequence
         |> list.map(highlight)
         |> string.join("")
@@ -183,7 +184,9 @@ pub fn mk_generic_serializer(separator: String, around: fn(String) -> String) {
           "" -> ""
           _ -> separator
         }
-        acc <> segment_separator <> {
+        acc
+        <> segment_separator
+        <> {
           sequence
           |> list.map(string.inspect)
           |> list.map(highlight)
@@ -205,29 +208,21 @@ fn to_strings(
 ) -> StyledComparison {
   let first_styled =
     first
-    |> list.fold(
-      "",
-      fn(str, match) {
-        case match {
-          Match(item) -> serializer(Part(str, item, no_highlight))
-          NoMatch(item) -> serializer(Part(str, item, first_highlight))
-        }
-      },
-    )
+    |> list.fold("", fn(str, match) {
+      case match {
+        Match(item) -> serializer(Part(str, item, no_highlight))
+        NoMatch(item) -> serializer(Part(str, item, first_highlight))
+      }
+    })
   let second_styled =
     second
-    |> list.fold(
-      "",
-      fn(str, match) {
-        case match {
-          Match(item) -> serializer(Part(str, item, no_highlight))
-          NoMatch(item) -> serializer(Part(str, item, second_highlight))
-        }
-      },
-    )
+    |> list.fold("", fn(str, match) {
+      case match {
+        Match(item) -> serializer(Part(str, item, no_highlight))
+        NoMatch(item) -> serializer(Part(str, item, second_highlight))
+      }
+    })
 
-  StyledComparison(
-    serializer(All(first_styled)),
-    serializer(All(second_styled)),
+  StyledComparison(serializer(All(first_styled)), serializer(All(second_styled)),
   )
 }

--- a/test/gap_test.gleam
+++ b/test/gap_test.gleam
@@ -62,66 +62,70 @@ pub fn compare_strings_test() {
       gap.myers,
     )
   comparison
-  |> should.equal(StringComparison(
-    [
-      Match(["a"]),
-      Match([" "]),
-      Match(["t"]),
-      Match(["e"]),
-      NoMatch(["s", "t"]),
-      Match([" ", "s", "t"]),
-      NoMatch(["i"]),
-      Match(["r"]),
-      Match(["n", "g", " ", "w", "i", "t", "h", " "]),
-      NoMatch(["s", "o"]),
-      Match(["m"]),
-      Match(["e", " ", "l", "e", "t", "t", "e", "r", "s"]),
-    ],
-    [
-      Match(["a"]),
-      NoMatch(["n", "d"]),
-      Match([" "]),
-      NoMatch(["a", "n", "o"]),
-      Match(["t"]),
-      NoMatch(["h"]),
-      Match(["e"]),
-      NoMatch(["r"]),
-      Match([" ", "s", "t"]),
-      Match(["r"]),
-      NoMatch(["i"]),
-      Match(["n", "g", " ", "w", "i", "t", "h", " "]),
-      Match(["m"]),
-      NoMatch(["o", "r"]),
-      Match(["e", " ", "l", "e", "t", "t", "e", "r", "s"]),
-    ],
-  ))
+  |> should.equal(
+    StringComparison(
+      [
+        Match(["a"]),
+        Match([" "]),
+        Match(["t"]),
+        Match(["e"]),
+        NoMatch(["s", "t"]),
+        Match([" ", "s", "t"]),
+        NoMatch(["i"]),
+        Match(["r"]),
+        Match(["n", "g", " ", "w", "i", "t", "h", " "]),
+        NoMatch(["s", "o"]),
+        Match(["m"]),
+        Match(["e", " ", "l", "e", "t", "t", "e", "r", "s"]),
+      ],
+      [
+        Match(["a"]),
+        NoMatch(["n", "d"]),
+        Match([" "]),
+        NoMatch(["a", "n", "o"]),
+        Match(["t"]),
+        NoMatch(["h"]),
+        Match(["e"]),
+        NoMatch(["r"]),
+        Match([" ", "s", "t"]),
+        Match(["r"]),
+        NoMatch(["i"]),
+        Match(["n", "g", " ", "w", "i", "t", "h", " "]),
+        Match(["m"]),
+        NoMatch(["o", "r"]),
+        Match(["e", " ", "l", "e", "t", "t", "e", "r", "s"]),
+      ],
+    ),
+  )
 
   compare_strings(
     "a long string with some small diffs",
     "a lon string with some snall diff",
   )
-  |> should.equal(StringComparison(
-    [
-      Match(["a", " ", "l", "o", "n"]),
-      NoMatch(["g"]),
-      Match([
-        " ", "s", "t", "r", "i", "n", "g", " ", "w", "i", "t", "h", " ", "s",
-        "o", "m", "e", " ", "s",
-      ]),
-      NoMatch(["m"]),
-      Match(["a", "l", "l", " ", "d", "i", "f", "f"]),
-      NoMatch(["s"]),
-    ],
-    [
-      Match(["a", " ", "l", "o", "n"]),
-      Match([
-        " ", "s", "t", "r", "i", "n", "g", " ", "w", "i", "t", "h", " ", "s",
-        "o", "m", "e", " ", "s",
-      ]),
-      NoMatch(["n"]),
-      Match(["a", "l", "l", " ", "d", "i", "f", "f"]),
-    ],
-  ))
+  |> should.equal(
+    StringComparison(
+      [
+        Match(["a", " ", "l", "o", "n"]),
+        NoMatch(["g"]),
+        Match([
+          " ", "s", "t", "r", "i", "n", "g", " ", "w", "i", "t", "h", " ", "s",
+          "o", "m", "e", " ", "s",
+        ]),
+        NoMatch(["m"]),
+        Match(["a", "l", "l", " ", "d", "i", "f", "f"]),
+        NoMatch(["s"]),
+      ],
+      [
+        Match(["a", " ", "l", "o", "n"]),
+        Match([
+          " ", "s", "t", "r", "i", "n", "g", " ", "w", "i", "t", "h", " ", "s",
+          "o", "m", "e", " ", "s",
+        ]),
+        NoMatch(["n"]),
+        Match(["a", "l", "l", " ", "d", "i", "f", "f"]),
+      ],
+    ),
+  )
 }
 
 pub fn compare_strings_lcs_test() {
@@ -130,98 +134,110 @@ pub fn compare_strings_lcs_test() {
     "and another string with more letters",
     gap.lcs,
   )
-  |> should.equal(StringComparison(
-    [
-      Match(["a", " ", "t", "e"]),
-      NoMatch(["s", "t"]),
-      Match([" ", "s", "t", "i"]),
-      NoMatch(["r"]),
-      Match(["n", "g", " ", "w", "i", "t", "h", " "]),
-      NoMatch(["s"]),
-      Match(["o"]),
-      NoMatch(["m"]),
-      Match(["e", " ", "l", "e", "t", "t", "e", "r", "s"]),
-    ],
-    [
-      Match(["a"]),
-      NoMatch(["n", "d"]),
-      Match([" "]),
-      NoMatch(["a", "n", "o"]),
-      Match(["t"]),
-      NoMatch(["h"]),
-      Match(["e"]),
-      NoMatch(["r"]),
-      Match([" ", "s", "t"]),
-      NoMatch(["r"]),
-      Match(["i", "n", "g", " ", "w", "i", "t", "h", " "]),
-      NoMatch(["m"]),
-      Match(["o"]),
-      NoMatch(["r"]),
-      Match(["e", " ", "l", "e", "t", "t", "e", "r", "s"]),
-    ],
-  ))
+  |> should.equal(
+    StringComparison(
+      [
+        Match(["a", " ", "t", "e"]),
+        NoMatch(["s", "t"]),
+        Match([" ", "s", "t", "i"]),
+        NoMatch(["r"]),
+        Match(["n", "g", " ", "w", "i", "t", "h", " "]),
+        NoMatch(["s"]),
+        Match(["o"]),
+        NoMatch(["m"]),
+        Match(["e", " ", "l", "e", "t", "t", "e", "r", "s"]),
+      ],
+      [
+        Match(["a"]),
+        NoMatch(["n", "d"]),
+        Match([" "]),
+        NoMatch(["a", "n", "o"]),
+        Match(["t"]),
+        NoMatch(["h"]),
+        Match(["e"]),
+        NoMatch(["r"]),
+        Match([" ", "s", "t"]),
+        NoMatch(["r"]),
+        Match(["i", "n", "g", " ", "w", "i", "t", "h", " "]),
+        NoMatch(["m"]),
+        Match(["o"]),
+        NoMatch(["r"]),
+        Match(["e", " ", "l", "e", "t", "t", "e", "r", "s"]),
+      ],
+    ),
+  )
 
   gap.compare_strings_with_algorithm(
     "a long string with some small diffs",
     "a lon string with some snall diff",
     gap.lcs,
   )
-  |> should.equal(StringComparison(
-    [
-      Match(["a", " ", "l", "o", "n"]),
-      NoMatch(["g"]),
-      Match([
-        " ", "s", "t", "r", "i", "n", "g", " ", "w", "i", "t", "h", " ", "s",
-        "o", "m", "e", " ", "s",
-      ]),
-      NoMatch(["m"]),
-      Match(["a", "l", "l", " ", "d", "i", "f", "f"]),
-      NoMatch(["s"]),
-    ],
-    [
-      Match([
-        "a", " ", "l", "o", "n", " ", "s", "t", "r", "i", "n", "g", " ", "w",
-        "i", "t", "h", " ", "s", "o", "m", "e", " ", "s",
-      ]),
-      NoMatch(["n"]),
-      Match(["a", "l", "l", " ", "d", "i", "f", "f"]),
-    ],
-  ))
+  |> should.equal(
+    StringComparison(
+      [
+        Match(["a", " ", "l", "o", "n"]),
+        NoMatch(["g"]),
+        Match([
+          " ", "s", "t", "r", "i", "n", "g", " ", "w", "i", "t", "h", " ", "s",
+          "o", "m", "e", " ", "s",
+        ]),
+        NoMatch(["m"]),
+        Match(["a", "l", "l", " ", "d", "i", "f", "f"]),
+        NoMatch(["s"]),
+      ],
+      [
+        Match([
+          "a", " ", "l", "o", "n", " ", "s", "t", "r", "i", "n", "g", " ", "w",
+          "i", "t", "h", " ", "s", "o", "m", "e", " ", "s",
+        ]),
+        NoMatch(["n"]),
+        Match(["a", "l", "l", " ", "d", "i", "f", "f"]),
+      ],
+    ),
+  )
 }
 
 pub fn compare_lists_test() {
   compare_lists([1, 2, 3, 4, 5], [1, 3, 4, 5, 6])
-  |> should.equal(ListComparison(
-    [Match([1]), NoMatch([2]), Match([3, 4, 5])],
-    [Match([1]), Match([3, 4, 5]), NoMatch([6])],
-  ))
+  |> should.equal(
+    ListComparison([Match([1]), NoMatch([2]), Match([3, 4, 5])], [
+      Match([1]),
+      Match([3, 4, 5]),
+      NoMatch([6]),
+    ]),
+  )
 }
 
 pub fn compare_lists_lcs_test() {
   gap.compare_lists_with_algorithm([1, 2, 3, 4, 5], [1, 3, 4, 5, 6], gap.lcs)
-  |> should.equal(ListComparison(
-    [Match([1]), NoMatch([2]), Match([3, 4, 5])],
-    [Match([1, 3, 4, 5]), NoMatch([6])],
-  ))
+  |> should.equal(
+    ListComparison([Match([1]), NoMatch([2]), Match([3, 4, 5])], [
+      Match([1, 3, 4, 5]),
+      NoMatch([6]),
+    ]),
+  )
 }
 
 pub fn compare_lists_custom_type_test() {
-  compare_lists(
-    [TestType("one", 1), TestType("two", 2), TestType("four", 4)],
-    [TestType("one", 1), TestType("three", 3), TestType("four", 4)],
+  compare_lists([TestType("one", 1), TestType("two", 2), TestType("four", 4)], [
+    TestType("one", 1),
+    TestType("three", 3),
+    TestType("four", 4),
+  ])
+  |> should.equal(
+    ListComparison(
+      [
+        Match([TestType("one", 1)]),
+        NoMatch([TestType("two", 2)]),
+        Match([TestType("four", 4)]),
+      ],
+      [
+        Match([TestType("one", 1)]),
+        NoMatch([TestType("three", 3)]),
+        Match([TestType("four", 4)]),
+      ],
+    ),
   )
-  |> should.equal(ListComparison(
-    [
-      Match([TestType("one", 1)]),
-      NoMatch([TestType("two", 2)]),
-      Match([TestType("four", 4)]),
-    ],
-    [
-      Match([TestType("one", 1)]),
-      NoMatch([TestType("three", 3)]),
-      Match([TestType("four", 4)]),
-    ],
-  ))
 }
 
 pub fn styled_comparison_test() {
@@ -244,10 +260,9 @@ pub fn styled_comparison_serializer_test() {
     fn(item) { "#" <> item <> "#" },
     no_highlight,
   )
-  |> serialize(mk_generic_serializer(
-    " :: ",
-    fn(all) { "--> " <> all <> " <--" },
-  ))
+  |> serialize(
+    mk_generic_serializer(" :: ", fn(all) { "--> " <> all <> " <--" }),
+  )
   |> to_styled_comparison()
   |> should.equal(StyledComparison(
     "--> 1 :: >2< :: 3 :: 4 :: 5 <--",
@@ -303,10 +318,9 @@ pub fn demo() {
       fn(item) { ansi.cyan(item) },
       no_highlight,
     )
-    |> serialize(mk_generic_serializer(
-      " and ",
-      fn(all) { "Comparison(" <> all <> ")" },
-    ))
+    |> serialize(
+      mk_generic_serializer(" and ", fn(all) { "Comparison(" <> all <> ")" }),
+    )
     |> to_styled_comparison()
   io.println(comparison.first)
   io.println(comparison.second)
@@ -361,10 +375,11 @@ pub fn demo() {
       fn(second) { second <> " was not found in other" },
       fn(matching) { matching <> " was found in other" },
     )
-    |> serialize(mk_generic_serializer(
-      ", and ",
-      fn(result) { "Comparing the lists gave the following result: " <> result },
-    ))
+    |> serialize(
+      mk_generic_serializer(", and ", fn(result) {
+        "Comparing the lists gave the following result: " <> result
+      }),
+    )
     |> to_styled_comparison()
   io.println(comparison.first)
   io.println(comparison.second)
@@ -382,19 +397,21 @@ pub fn demo() {
       ],
     )
     |> from_comparison()
-    |> highlight(
-      fn(first) { "+" <> first },
-      fn(second) { "-" <> second },
-      fn(matching) { " " <> matching },
-    )
+    |> highlight(fn(first) { "+" <> first }, fn(second) { "-" <> second }, fn(
+      matching,
+    ) {
+      " " <> matching
+    })
     |> serialize(fn(part) {
       case part {
         Part(acc, lines, highlight) ->
-          acc <> {
+          acc
+          <> {
             lines
             |> list.map(fn(line) { highlight(line) })
             |> string.join("\n")
-          } <> "\n"
+          }
+          <> "\n"
         All(result) -> result
       }
     })


### PR DESCRIPTION
I am working on updating the exercism test runner for the gleam track. This is listed as a dependency and needed to be upgraded to support the most recent version of Gleam.  

It seems there were a few API changes - namely switching from `map` to `dict` and potentially also the argument order of `index_map`.  

I also wasn't sure how to handle the exhaustive cases for `proceed_path`.

Happy to make any changes necessary! 